### PR TITLE
Feature/unittest signup

### DIFF
--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,86 @@
+import unittest
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+# Import create_app from your Flask factory setup
+from app import create_app, db
+from app.models import User
+
+class TestConfig:
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    WTF_CSRF_ENABLED = False
+    SECRET_KEY = "test-secret-key"  
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+
+class TestLogin(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(TestConfig)
+        # Ensure SECRET_KEY is set in the app's config directly as well
+        self.app.config['SECRET_KEY'] = TestConfig.SECRET_KEY
+        
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+        # Create dummy user for login tests
+        user = User(name="Test", username="tester", age=25, gender="female", email="test@example.com")
+        user.password = "testpass123"
+        db.session.add(user)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_login_missing_fields(self):
+        """❌ Login form missing field validation."""
+        # Missing password
+        response = self.client.post('/login', data={
+            'email': 'test@example.com',
+            'password': ''
+        }, follow_redirects=True)
+        self.assertIn(b'Login', response.data)
+
+        # Missing email
+        response = self.client.post('/login', data={
+            'email': '',
+            'password': 'testpass123'
+        }, follow_redirects=True)
+        self.assertIn(b'Login', response.data)
+        self.assertEqual(response.status_code, 200)
+    
+    def test_login_invalid_credentials(self):
+        """Test login with invalid credentials"""
+        # Ensure app has a secret key for session/flash functionality
+        response = self.client.post('/login', data={
+            'email': 'nonexistent@test.com',
+            'password': 'wrongpassword'
+        }, follow_redirects=True)
+        self.assertIn(b'Login', response.data)
+        self.assertIn(b'Invalid email or password', response.data)
+        self.assertEqual(response.status_code, 200)
+    
+    def test_login_route_get(self):
+        """Test the login page loads correctly"""
+        response = self.client.get('/login')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Login', response.data)
+    
+    def test_successful_login(self):
+        """Test successful login with valid credentials"""
+        response = self.client.post('/login', data={
+            'email': 'test@example.com',
+            'password': 'testpass123'
+        }, follow_redirects=True)
+        # Check for successful login indicators - modify these assertions based on your app's behavior
+        self.assertEqual(response.status_code, 200)
+        # Usually there would be a welcome message or redirect to a dashboard
+        # self.assertIn(b'Welcome', response.data)  # Uncomment and modify as needed
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,91 @@
+import unittest
+from datetime import datetime
+import os
+import sys
+
+# Get absolute path to project root
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Define TestConfig within the test file
+class TestConfig:
+    SECRET_KEY = 'test-secret-key'
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    WTF_CSRF_ENABLED = False
+
+from app import create_app, db
+from app.models import User
+
+class TestSignUp(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(TestConfig)
+        self.app.config['SECRET_KEY'] = TestConfig.SECRET_KEY
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+        db.create_all()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.ctx.pop()
+
+    def test_user_creation_and_password_hashing(self):
+        """✅ Test user creation and password hashing works correctly."""
+        response = self.client.post('/signup', data={
+            'name': 'Test User',
+            'username': 'testuser',
+            'age': 20,
+            'gender': 'female',
+            'email': f'user{datetime.now().timestamp()}@test.com',
+            'password': 'securepass123',
+            'confirm_password': 'securepass123'
+        }, follow_redirects=True)
+
+        user = User.query.filter_by(username='testuser').first()
+        self.assertIsNotNone(user, "User should be created in the database")
+        self.assertNotEqual(user.password_hash, 'securepass123')
+        self.assertTrue(user.check_password('securepass123'))
+
+    def test_duplicate_email_registration(self):
+        email = f'dupe{datetime.now().timestamp()}@test.com'
+        user1 = User(name='First', username='firstuser', age=25, gender='female', email=email)
+        user1.password = 'firstpass'
+        db.session.add(user1)
+        db.session.commit()
+
+        response = self.client.post('/signup', data={
+            'name': 'Second',
+            'username': 'seconduser',
+            'age': 22,
+            'gender': 'female',
+            'email': email,
+            'password': 'secondpass',
+            'confirm_password': 'secondpass'
+        }, follow_redirects=True)
+
+        users = User.query.filter_by(email=email).all()
+        self.assertEqual(len(users), 1,)
+
+    def test_duplicate_username_registration(self):
+        username = "duplicateuser"
+        user1 = User(name="User One", username=username, age=25, gender="female", email="user1@example.com")
+        user1.password = "pass123"
+        db.session.add(user1)
+        db.session.commit()
+
+        response = self.client.post("/signup", data={
+            "name": "User Two",
+            "username": username,
+            "age": 28,
+            "gender": "female",
+            "email": f"user2{datetime.now().timestamp()}@example.com",
+            "password": "pass1234",
+            "confirm_password": "pass1234"
+        }, follow_redirects=True)
+
+        users_with_same_username = User.query.filter_by(username=username).all()
+        self.assertEqual(len(users_with_same_username), 1,)


### PR DESCRIPTION
Hi team,

This PR introduces `unittest`-based tests for the `/signup` functionality, adapted to align with our project conventions (as discussed with Chloe):

### ✅ What’s included:
- Converted `pytest`-style to `unittest` framework as per rubric
- Implemented tests using `create_app(TestConfig)` factory
- CSRF disabled and SQLite in-memory DB used for test isolation

### 🔍 Tests Covered:
1. `test_user_creation_and_password_hashing` – checks user creation and password hash logic
2. `test_duplicate_email_registration` – prevents sign-up with the same email
3. `test_duplicate_username_registration` – prevents sign-up with duplicate username

### 🛠️ Notes:
- implementation with proper unittest format
- I’ve removed flash message assertions to avoid inconsistencies with current UI handling

Regarding the overlap:  
My intention was to demonstrate working functionality and get early feedback before migrating tests to the correct structure. After receiving Chloe’s guidance, I’ve adjusted everything accordingly and will now be focusing on Selenium tests as suggested.

This `test_signup.py` should now fit our project expectations. I hope we can include these test cases as part of the final evaluation.

Thanks!  
